### PR TITLE
[BUGFIX] TYPO3 6.0 compatibility for CLI runner

### DIFF
--- a/classes/class.tx_caretaker_Cli.php
+++ b/classes/class.tx_caretaker_Cli.php
@@ -52,7 +52,7 @@ class tx_caretaker_Cli extends t3lib_cli {
 	 */
 	public function __construct() {
 		// Running parent class constructor
-		parent::t3lib_cli();
+		parent::__construct();
 
 			// Setting help texts:
         $this->cli_help['name'] = 'Caretaker CLI-Testrunner';


### PR DESCRIPTION
The CLI runner did not work on TYPO3 6.0 anymore because
the CLI parent class was renamed.

Fixes: #45283

http://forge.typo3.org/issues/45283
