### PR TITLE
[FEATURE] unregister cli notification on scheduler task run

### DIFF
--- a/classes/helpers/class.tx_caretaker_ServiceHelper.php
+++ b/classes/helpers/class.tx_caretaker_ServiceHelper.php
@@ -164,6 +164,19 @@ class tx_caretaker_ServiceHelper {
 	}
 
 	/**
+	 * Unregister a caretaker notification service.
+	 *
+	 * @param string $serviceKey  key wich is used for the service
+	 *
+	 * @return void
+	 */
+	public static function unregisterCaretakerNotificationService ( $serviceKey ){
+		if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['caretaker']['notificationServices'][$serviceKey]) ){
+			unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['caretaker']['notificationServices'][$serviceKey]);
+		}
+	}
+
+	/**
 	 * Returns an array with all services with the type "caretaker_notification_service"
 	 *
 	 * @return array

--- a/classes/services/notifications/class.tx_caretaker_CliNotificationService.php
+++ b/classes/services/notifications/class.tx_caretaker_CliNotificationService.php
@@ -60,8 +60,6 @@ class tx_caretaker_CliNotificationService extends tx_caretaker_AbstractNotificat
 	 * @param tx_caretaKer_TestResult $lastResult
 	 */
 	public function addNotification($event, $node, $result = NULL, $lastResult = NULL) {
-		if (TYPO3_cliKey === 'scheduler') return;
-
 		$indent = $this->getCliIndentation($node);
 
 		if ( is_a ($node, 'tx_caretaker_TestNode' )  ) {

--- a/scheduler/class.tx_caretaker_testrunnertask.php
+++ b/scheduler/class.tx_caretaker_testrunnertask.php
@@ -66,6 +66,8 @@ class tx_caretaker_TestrunnerTask extends tx_scheduler_Task {
 		if (!$node)return false;
 
 		$lockObj = t3lib_div::makeInstance('t3lib_lock', 'tx_caretaker_update_'.$node->getCaretakerNodeId() , $GLOBALS['TYPO3_CONF_VARS']['SYS']['lockingMode'] );
+			// no output during scheduler runs
+		tx_caretaker_ServiceHelper::unregisterCaretakerNotificationService( 'CliNotificationService' );
 
 		if( $lockObj->acquire() ) {
 		   	$node->updateTestResult();


### PR DESCRIPTION
Instead of checking for a CLI key, the test runner scheduler task
unregisters the cli notification service.
This will always work, regardless of the way the scheduler is invoked.

Fixes: http://forge.typo3.org/issues/36593
