### PR TITLE
FIX: t3lib_mail_Message->setFrom() won't work with non plain addresses

### DIFF
--- a/classes/services/notifications/advanced/exitpoints/class.tx_caretaker_NotificationMailExitPoint.php
+++ b/classes/services/notifications/advanced/exitpoints/class.tx_caretaker_NotificationMailExitPoint.php
@@ -93,7 +93,7 @@ class tx_caretaker_NotificationMailExitPoint extends tx_caretaker_NotificationBa
 	 */
 	protected function sendMail($recipient, $mailContent) {
 		$mail = t3lib_div::makeInstance('t3lib_mail_Message');
-		$mail->setFrom($this->config['emailSenderName'] . '<' . $this->config['emailSenderAddress'] . '>');
+		$mail->setFrom($this->config['emailSenderAddress'], $this->config['emailSenderName']);
 		$mail->setTo($recipient);
 		$mail->setSubject($mailContent['subject']);
 		$mail->setBody($mailContent['message']);


### PR DESCRIPTION
setFrom() only works with plain mail addresses. Having the from address set to "Caretaker caretaker@domain.tld" leads directly to a core exception. The function setFrom() provides a second optional parameter for the senders name.

Core: Exception handler (CLI): Uncaught TYPO3 Exception: Address in mailbox given [Caretaker caretaker@domain.tdl] does not comply with RFC 2822, 3.6.2. | Swift_RfcComplianceException thrown in file typo3/contrib/swiftmailer/classes/Swift/Mime/Headers/MailboxHeader.php in line 309

Due to this exception no mail is sent at all.
