### PR TITLE
[FIX] Compatibility with TYPO3 CMS 7.5

### DIFF
--- a/classes/helpers/class.tx_caretaker_LocalizationHelper.php
+++ b/classes/helpers/class.tx_caretaker_LocalizationHelper.php
@@ -95,7 +95,7 @@ class tx_caretaker_LocalizationHelper {
 					$locallang_file = implode(':', $locallangParts);
 
 					$language_key = $GLOBALS['BE_USER']->uc['lang'];
-					$LANG = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('language');
+					$LANG = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Lang\LanguageService');
 					$LANG->init($language_key);
 					$result = $LANG->getLLL(
 							$locallang_key,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,15 +45,52 @@ if (TYPO3_MODE == 'BE') {
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'pi_abstract/class.tx_caretaker_pi_abstract.php', '_pi_abstract', 'list_type', 0);
 
 // Add eID script for caretaker tree loader
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::treeloader'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_TreeLoader.php:tx_caretaker_TreeLoader->ajaxLoadTree';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodeinfo'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeInfo';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::noderefresh'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxRefreshNode';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodegraph'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeGraph';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodelog'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeLog';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodeproblems'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeProblems';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodecontacts'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeContacts';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodeSetAck'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxNodeSetAck';
-$TYPO3_CONF_VARS['BE']['AJAX']['tx_caretaker::nodeSetDue'] = 'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxNodeSetDue';
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::treeloader',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_TreeLoader.php:tx_caretaker_TreeLoader->ajaxLoadTree',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodeinfo',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeInfo',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::noderefresh',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxRefreshNode',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodegraph',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeGraph',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodelog',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeLog',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodeproblems',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeProblems',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodecontacts',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxGetNodeContacts',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodeSetAck',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxNodeSetAck',
+	FALSE
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+	'tx_caretaker::nodeSetDue',
+	'EXT:caretaker/classes/ajax/class.tx_caretaker_NodeInfo.php:tx_caretaker_nodeinfo->ajaxNodeSetDue',
+	FALSE
+);
 
 
 $TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tceforms.php']['getSingleFieldClass'][] = 'EXT:caretaker/classes/hooks/class.tx_caretaker_hooks_tceforms_getSingleFieldClass.php:tx_caretaker_hooks_tceforms_getSingleFieldClass';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -47,6 +47,7 @@ $TCA['tx_caretaker_instancegroup'] = array(
 				'label' => 'title',
 				'tstamp' => 'tstamp',
 				'crdate' => 'crdate',
+				'type' => '',
 				'cruser_id' => 'cruser_id',
 				'default_sortby' => 'ORDER BY title',
 				'delete' => 'deleted',
@@ -60,7 +61,7 @@ $TCA['tx_caretaker_instancegroup'] = array(
 				),
 				'dividers2tabs' => 1,
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/instancegroup.png',
+				'iconfile' => 'EXT:caretaker/res/icons/instancegroup.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -85,7 +86,7 @@ $TCA['tx_caretaker_instance'] = array(
 				),
 				'dividers2tabs' => 1,
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/instance.png',
+				'iconfile' => 'EXT:caretaker/res/icons/instance.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -112,7 +113,7 @@ $TCA['tx_caretaker_testgroup'] = array(
 				),
 				'dividers2tabs' => 1,
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/group.png',
+				'iconfile' => 'EXT:caretaker/res/icons/group.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -137,7 +138,7 @@ $TCA['tx_caretaker_roles'] = array(
 						'disabled' => 'hidden',
 				),
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/role.png',
+				'iconfile' => 'EXT:caretaker/res/icons/role.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -153,7 +154,7 @@ $TCA['tx_caretaker_node_address_mm'] = array(
 				'label_alt_force' => 1,
 
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/nodeaddressrelation.png',
+				'iconfile' => 'EXT:caretaker/res/icons/nodeaddressrelation.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -176,7 +177,7 @@ $TCA['tx_caretaker_contactaddress'] = array(
 				),
 				'dividers2tabs' => 1,
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/contactaddress.png',
+				'iconfile' => 'EXT:caretaker/res/icons/contactaddress.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',
@@ -195,7 +196,7 @@ if ($advancedNotificationsEnabled) {
 					'label' => 'uid_strategy',
 
 					'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-					'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/nodeaddressrelation.png',
+					'iconfile' => 'EXT:caretaker/res/icons/nodeaddressrelation.png',
 			),
 			'feInterface' => array(
 					'fe_admin_fieldList' => '',
@@ -216,7 +217,7 @@ if ($advancedNotificationsEnabled) {
 							'disabled' => 'hidden',
 					),
 					'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-					'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/exitpoint.png',
+					'iconfile' => 'EXT:caretaker/res/icons/exitpoint.png',
 					'requestUpdate' => 'service',
 			),
 			'feInterface' => array(
@@ -238,7 +239,7 @@ if ($advancedNotificationsEnabled) {
 							'disabled' => 'hidden',
 					),
 					'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-					'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/strategy.png',
+					'iconfile' => 'EXT:caretaker/res/icons/strategy.png',
 			),
 			'feInterface' => array(
 					'fe_admin_fieldList' => '',
@@ -265,7 +266,7 @@ $TCA['tx_caretaker_test'] = array(
 						'fe_group' => 'fe_group',
 				),
 				'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'tca.php',
-				'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'res/icons/test.png',
+				'iconfile' => 'EXT:caretaker/res/icons/test.png',
 		),
 		'feInterface' => array(
 				'fe_admin_fieldList' => '',

--- a/mod_nav/index.php
+++ b/mod_nav/index.php
@@ -73,14 +73,13 @@ class tx_caretaker_mod_nav extends \TYPO3\CMS\Backend\Module\BaseScriptClass {
 
 		if ($BE_USER->user["admin"]) {
 			// Draw the header.
-			$this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance("template");
+			$this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate");
 			$this->doc->backPath = $BACK_PATH;
 
 			$this->pageRenderer = $this->doc->getPageRenderer();
 
 			// Include Ext JS
 			$this->pageRenderer->loadExtJS(true, true);
-			$this->pageRenderer->enableExtJSQuickTips();
 			$this->pageRenderer->enableExtJsDebug();
 			$this->pageRenderer->addJsFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('caretaker') . 'res/js/tx.caretaker.js', 'text/javascript', FALSE, FALSE);
 			$this->pageRenderer->addJsFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('caretaker') . 'res/js/tx.caretaker.NodeTree.js', 'text/javascript', FALSE, FALSE);

--- a/mod_overview/index.php
+++ b/mod_overview/index.php
@@ -88,7 +88,6 @@ class tx_caretaker_mod_nav extends \TYPO3\CMS\Backend\Module\BaseScriptClass {
 
 			// Include Ext JS
 			$this->pageRenderer->loadExtJS();
-			$this->pageRenderer->enableExtJSQuickTips();
 			$this->pageRenderer->addJsFile($BACK_PATH . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('caretaker') . 'res/js/tx.caretaker.js');
 
 			$panels = array();
@@ -130,8 +129,6 @@ class tx_caretaker_mod_nav extends \TYPO3\CMS\Backend\Module\BaseScriptClass {
 			$this->pageRenderer->addJsInlineCode('Caretaker_Overview', '
 				Ext.state.Manager.setProvider(new Ext.state.CookieProvider());
 				Ext.namespace("tx","tx.caretaker");
-
-				Ext.QuickTips.init();
 
 				Ext.onReady( function() {
 

--- a/res/css/tx.caretaker.nodetree.css
+++ b/res/css/tx.caretaker.nodetree.css
@@ -6,6 +6,7 @@
 	height: 14px;
 	border: none;
 	color:white;
+	box-sizing: content-box;
 }
 
 #ext-caretaker-mod-nav-index-php .x-panel-bwrap {

--- a/res/css/tx.caretaker.overview.css
+++ b/res/css/tx.caretaker.overview.css
@@ -6,6 +6,7 @@
 	height: 14px;
 	border: none;
 	color:white;
+	box-sizing: content-box;
 }
 
 #ext-caretaker-mod-overview-index-php .x-panel-tbar {

--- a/res/js/tx.caretaker.NodeToolbar.js
+++ b/res/js/tx.caretaker.NodeToolbar.js
@@ -12,25 +12,25 @@ tx.caretaker.NodeToolbar = Ext.extend(Ext.Toolbar, {
                     {
                           text    : "Refresh",
 						  xtype   : 'splitbutton',
-                          icon    : "../res/icons/arrow_refresh_small.png",
+                          icon    : "../typo3conf/ext/caretaker/res/icons/arrow_refresh_small.png",
                           handler : this.refreschNode,
 							scope   : this
                     },
                     {
                           text    : "Actions",
                           xtype   : 'splitbutton',
-                          icon    : "../res/icons/arrow_refresh_small.png",
+                          icon    : "../typo3conf/ext/caretaker/res/icons/arrow_refresh_small.png",
                           menu    : [
                                 
                                  {
                                      text    : "Refresh forced",
-                                     icon    : "../res/icons/arrow_refresh.png",
+                                     icon    : "../typo3conf/ext/caretaker/res/icons/arrow_refresh.png",
                                      handler : this.refreschNodeForced,
              						 scope   : this
                                  },
                                  {
                                      text    : "Acknowledge Problem",
-                                     icon    : "../res/icons/wip.png",
+                                     icon    : "../typo3conf/ext/caretaker/res/icons/wip.png",
                                      handler : this.setAck,
                                      id      : 'tx_caretaker_NodeToolbar_Ack',
                                      disabled  : ( config.node_type == "test" && config.node_state_info == "ACK") ? true:false,
@@ -39,7 +39,7 @@ tx.caretaker.NodeToolbar = Ext.extend(Ext.Toolbar, {
              	                },
              	                {
                                      text    : "Set Due to Execution",
-                                     icon    : "../res/icons/wip.png",
+                                     icon    : "../typo3conf/ext/caretaker/res/icons/wip.png",
                                      handler : this.setDue,
                                      id      : 'tx_caretaker_NodeToolbar_Due',
                                      disabled  : ( config.node_type == "test" && config.node_state_info == "DUE") ? true:false,
@@ -51,40 +51,40 @@ tx.caretaker.NodeToolbar = Ext.extend(Ext.Toolbar, {
                     {
                             text    : "Edit",
 							xtype   : 'splitbutton',
-                            icon    : "../res/icons/pencil.png",
+                            icon    : "../typo3conf/ext/caretaker/res/icons/pencil.png",
                             disabled: (config.node_type =='root')?true:false,
                             handler : this.editNode,
 							scope   : this
                     },{
                             text    : "Add Child Record",
 							xtype   : 'splitbutton',
-                            icon    : "../res/icons/add.png",
+                            icon    : "../typo3conf/ext/caretaker/res/icons/add.png",
 							menu    : [
 								{
 									text    : "Add Instancegroup",
 				                	id      : 'toolbar-menu-add-instancegroup',
-									icon    : "../res/icons/instancegroup.png",
+									icon    : "../typo3conf/ext/caretaker/res/icons/instancegroup.png",
 									disabled: true,
 									handler : this.addInstancegroup,
 									scope   : this
 								},{
 									text    : "Add Instance",
 				                	id      : 'toolbar-menu-add-instance',
-									icon    : "../res/icons/instance.png",
+									icon    : "../typo3conf/ext/caretaker/res/icons/instance.png",
 									disabled: true,
 									handler : this.addInstance,
 									scope   : this
 								},{
 									text    : "Add Testgroup",
 									id      : 'toolbar-menu-add-testgroup',
-									icon    : "../res/icons/group.png",
+									icon    : "../typo3conf/ext/caretaker/res/icons/group.png",
 									disabled: true,
 									handler : this.addTestgroup,
 									scope   : this
 								},{
 									text    : "Add Test",
 									id      : 'toolbar-menu-add-test',
-									icon    : "../res/icons/test.png",
+									icon    : "../typo3conf/ext/caretaker/res/icons/test.png",
 									disabled: true,
 									handler : this.addTest,
 									scope   : this
@@ -95,14 +95,14 @@ tx.caretaker.NodeToolbar = Ext.extend(Ext.Toolbar, {
                             text    : "Enable",
 							xtype   : 'splitbutton',
                             disabled: (config.node_hidden==0 || config.node_type=='root')?true:false,
-                            icon    : "../res/icons/lightbulb.png",
+                            icon    : "../typo3conf/ext/caretaker/res/icons/lightbulb.png",
                             handler : this.enableNode,
 							scope   : this
                     },
                     {
                             text    : "Disable",
 							xtype   : 'splitbutton',
-                            icon    : "../res/icons/lightbulb_off.png",
+                            icon    : "../typo3conf/ext/caretaker/res/icons/lightbulb_off.png",
                             disabled: (config.node_hidden==1 || config.node_type=='root')?true:false,
                             handler : this.disableNode,
 							scope   : this

--- a/res/js/tx.caretaker.NodeTree.js
+++ b/res/js/tx.caretaker.NodeTree.js
@@ -236,7 +236,7 @@ tx.caretaker.NodeTree = Ext.extend(Ext.tree.TreePanel, {
 	},
 	navigateToNodeDetails: function(node) {
 		var params = 'id=' + node.attributes.id;
-		var url = top.TS.PATH_typo3 + top.currentSubScript + '&' + params;
+		var url = top.currentSubScript + '&' + params;
 		this.openUrlInContent(url);
 	},
 	editNode: function(node) {

--- a/scheduler/class.tx_caretaker_testrunnertask_additionalfieldprovider.php
+++ b/scheduler/class.tx_caretaker_testrunnertask_additionalfieldprovider.php
@@ -22,6 +22,7 @@
  *
  * This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+use TYPO3\CMS\Scheduler\AdditionalFieldProviderInterface;
 
 /**
  * This is a file of the caretaker project.
@@ -33,7 +34,7 @@
  *
  * $Id$
  */
-class tx_caretaker_TestrunnerTask_AdditionalFieldProvider implements tx_scheduler_AdditionalFieldProvider {
+class tx_caretaker_TestrunnerTask_AdditionalFieldProvider implements AdditionalFieldProviderInterface {
 
 	/**
 	 * This method is used to define new fields for adding or editing a task

--- a/tca.php
+++ b/tca.php
@@ -292,7 +292,9 @@ $TCA['tx_caretaker_instance'] = array(
 										'edit' => Array(
 												'type' => 'popup',
 												'title' => 'Edit Test',
-												'script' => 'wizard_edit.php',
+												'module' => array(
+													'name' => 'wizard_edit'
+												),
 												'icon' => 'edit2.gif',
 												'popup_onlyOpenIfSelected' => 1,
 												'JSopenParams' => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
@@ -306,7 +308,9 @@ $TCA['tx_caretaker_instance'] = array(
 														'pid' => '###CURRENT_PID###',
 														'setValue' => 'prepend'
 												),
-												'script' => 'wizard_add.php',
+												'module' => array(
+													'name' => 'wizard_add'
+												)
 										),
 								),
 						)
@@ -420,7 +424,9 @@ $TCA['tx_caretaker_node_address_mm'] = array(
 														'pid' => '0',
 														'setValue' => 'prepend'
 												),
-												'script' => 'wizard_add.php'
+												'module' => array(
+													'name' => 'wizard_add'
+												)
 										)
 								)
 						)
@@ -629,7 +635,9 @@ $TCA['tx_caretaker_testgroup'] = array(
 										'edit' => Array(
 												'type' => 'popup',
 												'title' => 'Edit Test',
-												'script' => 'wizard_edit.php',
+												'module' => array(
+													'name' => 'wizard_edit'
+												),
 												'icon' => 'edit2.gif',
 												'popup_onlyOpenIfSelected' => 1,
 												'JSopenParams' => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
@@ -643,7 +651,9 @@ $TCA['tx_caretaker_testgroup'] = array(
 														'pid' => '###CURRENT_PID###',
 														'setValue' => 'prepend'
 												),
-												'script' => 'wizard_add.php',
+												'module' => array(
+													'name' => 'wizard_add'
+												)
 										),
 								),
 						)


### PR DESCRIPTION
The caretaker extension does not work with TYPO3 CMS 7.5

This patch corrects several points:
* old class names with namespace class names
* remove call to PageRendered::enableExtJSQuickTips as it was removed in 7.4
* fix module css to make headline appear as before
* adjust icon urls in ext js modules
* adjust url to navigateToNodeDetails in tx.caretaker.NodeTree.js
* use API introduced in 6.2 for registering ajax handlers for the backend
* use new syntax for record icon path in TCA
* use new syntax for configuring wizards in TCA (since 6.2)