### PR TITLE
[FIX] don't fail testrunner if lock could not be acquired

### DIFF
--- a/scheduler/class.tx_caretaker_testrunnertask.php
+++ b/scheduler/class.tx_caretaker_testrunnertask.php
@@ -84,7 +84,7 @@ class tx_caretaker_TestrunnerTask extends \TYPO3\CMS\Scheduler\Task\AbstractTask
 				$node->updateTestResult();
 				$lockObj->release();
 			} else {
-				return false;
+				return true;
 			}
 		} else {
 			$node->updateTestResult();


### PR DESCRIPTION
fixes #34