### PR TITLE
Bug-fixes

### DIFF
--- a/Classes/helpers/class.tx_caretaker_ServiceHelper.php
+++ b/Classes/helpers/class.tx_caretaker_ServiceHelper.php
@@ -164,7 +164,9 @@ class tx_caretaker_ServiceHelper {
 		$dsArray = array(
 			'default' => self::$tcaTestConfigDs['default']
 		);
-		$tests = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tx_caretaker_test', 'deleted=0');
+		if (isset($GLOBALS['TYPO3_DB'])) {
+		    $tests = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tx_caretaker_test', 'deleted=0');
+		}
 		if (!empty($tests)) {
 			foreach($tests as $testRecord) {
 				if(array_key_exists($testRecord['test_service'], self::$tcaTestConfigDs)) {

--- a/Configuration/TCA/tx_caretaker_node_address_mm.php
+++ b/Configuration/TCA/tx_caretaker_node_address_mm.php
@@ -7,6 +7,7 @@ $GLOBALS['TCA']['tx_caretaker_node_address_mm'] = array(
 		'label_alt' => 'role',
 		'label_alt_force' => 1,
 		'iconfile' => 'EXT:caretaker/res/icons/nodeaddressrelation.png',
+		'rootLevel' => -1,
 	),
 	'interface' => array(
 		'showRecordFieldList' => ''

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -419,3 +419,10 @@ CREATE TABLE tx_caretaker_strategies (
 CREATE TABLE fe_users (
 	tx_caretaker_api_key text NOT NULL
 );
+
+#
+# Table structure for table 'tt_address'
+#
+CREATE TABLE tt_address (
+	tx_caretaker_xmpp varchar(30) NOT NULL default ''
+);

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -52,6 +52,7 @@
 			<label index="tx_caretaker_instance.testconfigurations">Overwrite Test Configuration</label>
 
 			<label index="tx_caretaker_instance_override">Test configuration/curl option override</label>
+			<label index="tx_caretaker_instance_override.test_hidden">Hide</label>
 			<label index="tx_caretaker_instance_override.type">Type</label>
 			<label index="tx_caretaker_instance_override.type.test_configuration">Test configuration</label>
 			<label index="tx_caretaker_instance_override.type.curl_option">cURL option</label>


### PR DESCRIPTION
- 8de4301:
  If tt_address is installed, i can't create new tt_address records, because there is no field "tx_caretaker_xmpp" in the database: 
  
  > SQL error: 'Unknown column 'tx_caretaker_xmpp' in 'field list'' (tt_address:NEW5773f616be18d943463815)
- dfdf2e1:
  As default caretaker stores records on page 0, but it's not allowed to create 'tx_caretaker_node_address_mm' on root level:
  
  > Attempt to insert record on page '[root-level]' (0) where this table, tx_caretaker_node_address_mm, is not allowed
- 746ad3e:
  Solves https://github.com/TYPO3-Caretaker/caretaker/issues/59
- 715303b:
  In TYPO3 7.6.10 there is no label for the "hide checkbox" in "test configuration" flexform
