### PR TITLE
[BUGFIX] Initialize empty default datasturcture for exitpoints

### DIFF
--- a/Classes/helpers/class.tx_caretaker_ServiceHelper.php
+++ b/Classes/helpers/class.tx_caretaker_ServiceHelper.php
@@ -66,7 +66,9 @@ class tx_caretaker_ServiceHelper {
 	/**
 	 * @var array
 	 */
-	protected static $tcaExitPointConfigDs = array();
+	protected static $tcaExitPointConfigDs = array(
+	    'default' => '<?xml version="1.0" encoding="utf-8" standalone="yes" ?><T3DataStructure><meta></meta></T3DataStructure>',
+    );
 
 	/**
 	 * Array of all active Notification Services


### PR DESCRIPTION
Due to FormEngine changes in TYPO3 7.6 it is necessary to provide at
least an empty default configuration for FlexForm fields. This patch
ensures a proper configuration for field tx_caretaker_exitpoints:config