### PR TITLE
[BUGFIX] Use correct module name in advanced notification system

### DIFF
--- a/Classes/services/notifications/class.tx_caretaker_AbstractNotificationService.php
+++ b/Classes/services/notifications/class.tx_caretaker_AbstractNotificationService.php
@@ -125,7 +125,7 @@ class tx_caretaker_AbstractNotificationService implements tx_caretaker_Notificat
 	public function isEnabled() {
 		$enabled = (bool)$this->getConfigValue('enabled');
 		$beUsername = $GLOBALS["BE_USER"]->user['username'];
-		return ($enabled === TRUE && TYPO3_MODE == 'BE' && (defined('TYPO3_cliMode') && ($beUsername == '_cli_caretaker' || $beUsername == '_cli_scheduler') || $GLOBALS['MCONF']['name'] == 'tools_txschedulerM1'));
+		return ($enabled === TRUE && TYPO3_MODE == 'BE' && (defined('TYPO3_cliMode') && ($beUsername == '_cli_caretaker' || $beUsername == '_cli_scheduler') || !empty($GLOBALS['SOBE']) && $GLOBALS['SOBE']->MCONF['name'] == 'system_txschedulerM1'));
 	}
 
 	/**


### PR DESCRIPTION
The advanced notification system checks its enable status depending
on current username or module settings. Currently a wrong (old)
module name is used as validation. This patch checks for the correct
scheduler module name.