### PR TITLE
[FEATURE] Extend curl options for HTTP test

### DIFF
--- a/Classes/services/tests/class.tx_caretaker_httpTestService.php
+++ b/Classes/services/tests/class.tx_caretaker_httpTestService.php
@@ -83,6 +83,8 @@ class tx_caretaker_httpTestService extends tx_caretaker_TestServiceBase
         $requestUsername = $this->getRequestUsername();
         $requestPassword = $this->getRequestPassword();
         $requestPort = $this->getRequestPort();
+        $requestUseragent = $this->getRequestUseragent();
+        $requestReferer = $this->getRequestReferer();
         $requestProxy = $this->getRequestProxy();
         $requestProxyport = $this->getRequestProxyport();
 
@@ -125,7 +127,7 @@ class tx_caretaker_httpTestService extends tx_caretaker_TestServiceBase
         }
 
         // execute query
-        list($time, $content, $info, $headers) = $this->executeCurlRequest($request_url, $timeError * 3, $requestPort, $requestMethod, $requestUsername, $requestPassword, $requestData, $requestProxy, $requestProxyport);
+        list($time, $content, $info, $headers) = $this->executeCurlRequest($request_url, $timeError * 3, $requestPort, $requestMethod, $requestUsername, $requestPassword, $requestData, $requestProxy, $requestProxyport, $requestUseragent, $requestReferer);
 
         $submessages = array();
 
@@ -558,6 +560,22 @@ class tx_caretaker_httpTestService extends tx_caretaker_TestServiceBase
     }
 
     /**
+     * @return string
+     */
+    protected function getRequestUseragent()
+    {
+        return $this->getConfigValue('request_useragent', '', 'sRequest');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getRequestReferer()
+    {
+        return $this->getConfigValue('request_referer', '', 'sRequest');
+    }
+
+    /**
      * Get the Proxy for the HTTP-request
      *
      * @return string
@@ -606,9 +624,11 @@ class tx_caretaker_httpTestService extends tx_caretaker_TestServiceBase
      * @param string $request_data
      * @param bool|string $request_proxy
      * @param bool|string $request_proxyport
+     * @param string $request_useragent
+     * @param string $request_referer
      * @return array time in seconds and status information im associatie arrays
      */
-    protected function executeCurlRequest($request_url, $timeout = 0, $request_port = false, $request_method = 'GET', $request_username = '', $request_password = '', $request_data = '', $request_proxy = false, $request_proxyport = false)
+    protected function executeCurlRequest($request_url, $timeout = 0, $request_port = false, $request_method = 'GET', $request_username = '', $request_password = '', $request_data = '', $request_proxy = false, $request_proxyport = false, $request_useragent = '', $request_referer = '')
     {
         $curl = curl_init();
 
@@ -622,6 +642,16 @@ class tx_caretaker_httpTestService extends tx_caretaker_TestServiceBase
         if ($request_username && $request_password) {
             curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
             curl_setopt($curl, CURLOPT_USERPWD, $request_username . ':' . $request_password);
+        }
+
+        // user agent
+        if (!empty($request_useragent)) {
+            curl_setopt($curl, CURLOPT_USERAGENT, $request_useragent);
+        }
+
+        // referer
+        if (!empty($request_referer)) {
+            curl_setopt($curl, CURLOPT_REFERER, $request_referer);
         }
 
         // port

--- a/Classes/services/tests/ds.tx_caretaker_httpTestService.xml
+++ b/Classes/services/tests/ds.tx_caretaker_httpTestService.xml
@@ -161,6 +161,28 @@
                         </TCEforms>
                     </request_data>
 
+                    <request_useragent>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:caretaker/Classes/services/tests/lll.tx_caretaker_httpTestService.xml:request_useragent
+                            </label>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </request_useragent>
+
+                    <request_referer>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:caretaker/Classes/services/tests/lll.tx_caretaker_httpTestService.xml:request_referer
+                            </label>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </request_referer>
+
                 </el>
             </ROOT>
         </sRequest>

--- a/Classes/services/tests/lll.tx_caretaker_httpTestService.xml
+++ b/Classes/services/tests/lll.tx_caretaker_httpTestService.xml
@@ -43,6 +43,8 @@
             <label index="request_method">Request HTTP-Method</label>
             <label index="request_port">Request HTTP-Port</label>
             <label index="request_data">Request HTTP-Data</label>
+            <label index="request_useragent">Request User-Agent header</label>
+            <label index="request_referer">Request Referer header</label>
 
             <!-- sheet proxy -->
             <label index="sheet_proxy">Proxy Setting</label>


### PR DESCRIPTION
This patch extends the curl options for an HTTP tests and adds the
possibility to add an user agent header as well as a referer header.