### PR TITLE
Fix/latest versions security

### DIFF
--- a/Classes/helpers/class.tx_caretaker_LatestVersionsHelper.php
+++ b/Classes/helpers/class.tx_caretaker_LatestVersionsHelper.php
@@ -53,6 +53,7 @@ class tx_caretaker_LatestVersionsHelper
 
     /**
      * @return bool
+     * @throws Exception
      */
     public static function updateLatestTypo3VersionRegistry()
     {
@@ -65,52 +66,14 @@ class tx_caretaker_LatestVersionsHelper
             );
         }
 
-        $max = array();
-        $stable = array();
-		$security = array();
-		$latestLts = $releases['latest_lts'];
-        foreach ($releases as $major => $details) {
-            if (is_array($details) && !empty($details['latest'])) {
-                $max[$major] = $details['latest'];
-            }
+        $latestVersions = self::getLatestFromReleases($releases);
 
-            if (is_array($details) && !empty($details['stable'])) {
-                $stable[$major] = $details['stable'];
-            }
-            if (is_array($details) && is_array($details['releases'])) {
-			    $found = false;
-			    $latestCheckedVersion = '';
-			    foreach ($details['releases'] as $version => $versionDetails) {
-			        $latestCheckedVersion = $version;
-                    // if major version > latest_lts check if bugfix part of version number == '0';
-                    // in that case this is the security update and stop searching
-                    if (version_compare($major, $latestLts, '>')) {
-                        if ($versionDetails['type'] === 'security') {
-                            $security[$major] = $version;
-                            $found = true;
-                            break;
-                        }
-                        // if versionDetails->type === 'security' then this is the security update; stop searching
-                        if (self::extractBugfixNumberFromVersion($version) === 0) {
-                            $security[$major] = $version;
-                            $found = true;
-                            break;
-                        }
-                        // if versionDetails->type === 'security' then this is the security update; stop searching
-                    } elseif ($versionDetails['type'] === 'security') {
-                        $security[$major] = $version;
-                        $found = true;
-                        break;
-                    }
-                }
-                if (!$found) {
-			        $security[$major] = $latestCheckedVersion;
-                }
-            }
-        }
-        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Registry')->set('tx_caretaker', 'TYPO3versions', $max);
-        \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Registry')->set('tx_caretaker', 'TYPO3versionsStable', $stable);
-		\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Registry')->set('tx_caretaker', 'TYPO3versionsSecurity', $security);
+        /** @var \TYPO3\CMS\Core\Registry $registry */
+        $registry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Core\Registry');
+        $registry->set('tx_caretaker', 'TYPO3versions', $latestVersions['max']);
+        $registry->set('tx_caretaker', 'TYPO3versionsStable', $latestVersions['stable']);
+        $registry->set('tx_caretaker', 'TYPO3versionsSecurity', $latestVersions['security']);
+
         return true;
     }
 
@@ -147,17 +110,37 @@ class tx_caretaker_LatestVersionsHelper
     }
 
     /**
-     * extracts the bugfix part of a version number
-     *
-     * @param string $version
-     * @return integer
+     * @param array $releases
+     * @return array
      */
-    protected static function extractBugfixNumberFromVersion($version)
+    public static function getLatestFromReleases($releases)
     {
-        $version = str_replace(array('_', ',', '-', '+'), '.', $version);
-        $version = preg_replace('/(\d)([^\d\.])/', '$1.$2', $version);
-        $version = preg_replace('/([^\d\.])(\d)/', '$1.$2', $version);
-        $versionParts = \TYPO3\CMS\Core\Utility\GeneralUtility::intExplode('.', $version, true, 3);
-        return $versionParts[2];
-	}
+        $max = array();
+        $stable = array();
+        $security = array();
+        foreach ($releases as $major => $details) {
+            if (is_array($details) && !empty($details['latest'])) {
+                $max[$major] = $details['latest'];
+            }
+
+            if (is_array($details) && !empty($details['stable'])) {
+                $stable[$major] = $details['stable'];
+            }
+            if (is_array($details) && is_array($details['releases'])) {
+                foreach ($details['releases'] as $version => $versionDetails) {
+                    $security[$major] = $version;
+                    if ($versionDetails['type'] === 'security') {
+                        $security[$major] = $version;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return array(
+                'max' => $max,
+                'stable' => $stable,
+                'security' => $security,
+        );
+    }
 }

--- a/Tests/Unit/Fixtures/versions.json
+++ b/Tests/Unit/Fixtures/versions.json
@@ -1,0 +1,88 @@
+{
+  "3": {
+    "releases": {
+      "3.0.2": {
+        "version": "3.0.2",
+        "type": "regular"
+      },
+      "3.0.1": {
+        "version": "3.0.1",
+        "type": "regular"
+      },
+      "3.0.0": {
+        "version": "3.0.0",
+        "type": "release"
+      }
+    },
+    "latest": "3.0.2",
+    "stable": "3.0.1",
+    "active": true
+  },
+  "2": {
+    "releases": {
+      "2.1.2": {
+        "version": "2.1.2",
+        "type": "regular"
+      },
+      "2.1.1": {
+        "version": "2.1.1",
+        "type": "security"
+      },
+      "2.1.0": {
+        "version": "2.1.0",
+        "type": "release"
+      },
+      "2.0.2": {
+        "version": "2.0.2",
+        "type": "regular"
+      },
+      "2.0.1": {
+        "version": "2.0.1",
+        "type": "security"
+      },
+      "2.0.0": {
+        "version": "2.0.0",
+        "type": "release"
+      }
+    },
+    "latest": "2.1.2",
+    "stable": "2.1.2",
+    "active": true
+  },
+  "1": {
+    "releases": {
+      "1.1.2": {
+        "version": "1.1.2",
+        "type": "regular"
+      },
+      "1.1.1": {
+        "version": "1.1.1",
+        "type": "security"
+      },
+      "1.1.0": {
+        "version": "1.1.0",
+        "type": "release"
+      },
+      "1.0.2": {
+        "version": "1.0.2",
+        "type": "regular"
+      },
+      "1.0.1": {
+        "version": "1.0.1",
+        "type": "security"
+      },
+      "1.0.0": {
+        "version": "1.0.0",
+        "type": "release"
+      }
+    },
+    "latest": "1.1.2",
+    "stable": "1.1.2",
+    "active": true
+  },
+
+  "latest_stable": "2.1.2",
+  "latest_old_stable": "1.1.2",
+  "latest_lts": "2.1.2",
+  "latest_old_lts": "1.1.2"
+}

--- a/Tests/Unit/LatestVersionsHelperTest.php
+++ b/Tests/Unit/LatestVersionsHelperTest.php
@@ -1,0 +1,69 @@
+<?php
+namespace Caretaker\Caretaker\Tests\Unit;
+
+use TYPO3\CMS\Core\Tests\UnitTestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/***************************************************************
+ * Copyright notice
+ *
+ * (c) 2009-2011 by n@work GmbH and networkteam GmbH
+ *
+ * All rights reserved
+ *
+ * This script is part of the Caretaker project. The Caretaker project
+ * is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * This is a file of the caretaker project.
+ * http://forge.typo3.org/projects/show/extension-caretaker
+ *
+ * Project sponsored by:
+ * n@work GmbH - http://www.work.de
+ * networkteam GmbH - http://www.networkteam.com/
+ */
+class LatestVersionsHelperTest extends UnitTestCase
+{
+
+    /**
+     * @var array
+     */
+    protected $releases;
+
+    public function setup()
+    {
+        $json = file_get_contents(GeneralUtility::getFileAbsFileName('EXT:caretaker/Tests/Unit/Fixtures/versions.json'));
+        $this->releases = json_decode($json, true);
+    }
+
+    public function testLatest()
+    {
+        $latest = \tx_caretaker_LatestVersionsHelper::getLatestFromReleases($this->releases);
+
+        $this->assertEquals('3.0.2', $latest['max']['3'], 'v3: latest release');
+        $this->assertEquals('3.0.1', $latest['stable']['3'], 'v3: stable release');
+        $this->assertEquals('3.0.0', $latest['security']['3'], 'v3: no security release falls back to the first release');
+
+        $this->assertEquals('2.1.2', $latest['max']['2'], 'v2: latest release');
+        $this->assertEquals('2.1.2', $latest['stable']['2'], 'v2: stable release');
+        $this->assertEquals('2.1.1', $latest['security']['2'], 'v2: security release');
+
+        $this->assertEquals('1.1.2', $latest['max']['1'], 'v1: latest release');
+        $this->assertEquals('1.1.2', $latest['stable']['1'], 'v1: stable release');
+        $this->assertEquals('1.1.1', $latest['security']['1'], 'v1: security release');
+    }
+}


### PR DESCRIPTION
I did refactor Jorgen/Jigals patch from #76 and added a basic unit test.

As I didnt get the intention of the "$major > $latestLts" comparsion, I just removed that part.

Also, if a major version just has regular releases, but no security releases yet, the "latest security" version would fallback to the PATCH version ".0".