### PR TITLE
[TASK] Replace deprecated calls to ContentObjectRenderer

### DIFF
--- a/Classes/helpers/class.tx_caretaker_LocalizationHelper.php
+++ b/Classes/helpers/class.tx_caretaker_LocalizationHelper.php
@@ -73,7 +73,7 @@ class tx_caretaker_LocalizationHelper
                     // FE
                     if ($GLOBALS['TSFE']) {
                         $lcObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
-                        $result = $lcObj->TEXT(array('data' => $locallangString));
+                        $result = $lcObj->cObjGetSingle('TEXT',array('data' => $locallangString));
                     } // eID
                     else {
                         /** @var \TYPO3\CMS\Lang\LanguageService $LANG */

--- a/Classes/services/tests/class.tx_caretaker_TestServiceBase.php
+++ b/Classes/services/tests/class.tx_caretaker_TestServiceBase.php
@@ -272,7 +272,7 @@ class tx_caretaker_TestServiceBase extends \TYPO3\CMS\Core\Service\AbstractServi
             case 'FE':
                 $lcObj = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
 
-                return $lcObj->TEXT(array('data' => $locallang_string));
+                return $lcObj->cObjGetSingle('TEXT', array('data' => $locallang_string));
 
             case 'BE':
                 $locallang_key = array_pop($locallang_parts);


### PR DESCRIPTION
Replace deprecated calls to ContentObjectRenderer for TYPO3 8.7 in order to fix the broken frontend plugins.